### PR TITLE
Reusable workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,6 +10,10 @@ It runs on `ubuntu-latest` and one of our supported version, currently `Python 3
 If the workflow is run from `master` it pushes the successfully build documentation to the `gh-pages` branch,
 if it is run from a `pull_request` the documentation is uploaded as an artifact to allow manual checks.
 
+Input parameters: 
+  - `extra-dependencies` - name of the extra dependencies required to run the tests (defaults to `doc`).
+  - `dependency-file` - name of the file which contains the dependencies (used to get a hash-id for the caching).
+
 This workflow should only be triggered on pushes to `master` and on `pull_request`s.
 
 ## Testing Suite
@@ -20,6 +24,8 @@ Tests run on a matrix of all supported operating systems (`ubuntu-20.04`, `ubunt
 Input parameters: 
   - `name` - an optional string, to identify different pytest-configurations (defaults to `tests`).
   - `pytest-options` - options to be passed on to `pytest`, e.g. `-m "not extended and not cern_network"` (defaults to an empty string).
+  - `extra-dependencies` - name of the extra dependencies required to run the tests (defaults to `test`).
+  - `dependency-file` - name of the file which contains the dependencies (used to get a hash-id for the caching).
 
 These tests are usually run in two stages, which is easy to achieve by calling the test with different `pytest-options`.
 It should be run on all push events except to `master`. 
@@ -34,19 +40,23 @@ Input parameters:
   - `src-dir` - a required string, which indicates the name of the directory 
                 containing the source-code for which the coverage is calculated.
   - `pytest-options` - options to be passed on to `pytest`, e.g. `-m "not cern_network"` (defaults to an empty string).
+  - `extra-dependencies` - name of the extra dependencies required to run the tests (defaults to `test`).
+  - `dependency-file` - name of the file which contains the dependencies (used to get a hash-id for the caching).
 
 Secrets:
   - `CC_TEST_REPORTER_ID` - The CodeClimate test-reporter ID.
 
-This workflow should be triggered on pushes to `master` and any push to a `pull request`
+This workflow should be triggered on pushes to `master` and any push to a `pull request`.
 
 ## Regular Testing
 
 A `cron` workflow runs the full testing suite, on all available operating systems and supported Python versions.
 It is very similar to the normal Testing Suite, but in addition also runs on `Python 3.x` so that newly released Python versions that would break tests are automatically included.
 
-Input parameters are: 
+Input parameters: 
   - `pytest-options` - options to be passed on to `pytest`, e.g. `-m "not cern_network"` (defaults to an empty string).
+  - `extra-dependencies` - name of the extra dependencies required to run the tests (defaults to `test`).
+  - `dependency-file` - name of the file which contains the dependencies (used to get a hash-id for the caching).
 
 The workflow should be triggered in regular intervals, e.g. every Monday at 3am (UTC time).
 
@@ -54,6 +64,9 @@ The workflow should be triggered in regular intervals, e.g. every Monday at 3am 
 
 Publishing to `PyPI` is done through the `publish` workflow, 
 which builds a `wheel`, checks it, and pushes to `PyPI` if checks are successful.
+
+Input parameters: 
+  - `dependency-file` - name of the file which contains the dependencies (used to get a hash-id for the caching).
 
 Secrets:
   - `PYPI_USERNAME` - The pypi username.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,60 @@
+# Continuous Integration Workflows
+
+This package implements different reusable workflows for CI.
+They are organized as follows.
+
+## Documentation
+
+The `documentation` workflow builds the documentation and pushes it to the `gh-pages` branch (if the build is successful).
+It runs on `ubuntu-latest` and one of our supported version, currently `Python 3.9`.
+
+It should be triggered on any push to `master`.
+
+## Testing Suite
+
+Tests are ensured in the `tests` workflow.
+Tests run on a matrix of all supported operating systems (`ubuntu-20.04`, `ubuntu-22.04`, `windows-latest` and `macos-latest`) for all supported Python versions (currently `3.8` to `3.11`).
+
+Input parameters: 
+  - `name` - an optional string, to identify different pytest-configurations (defaults to `tests`).
+  - `pytest-options` - options to be passed on to `pytest`, e.g. `-m "not extended and not cern_network"` (defaults to an empty string).
+
+These tests are usually run in two stages, which is easy to achieve by calling the test with different `pytest-options`.
+It should be run on all push events except to `master`. 
+The first stage runs our simple tests (the `basic` tests) , and the second one runs the rest of the testing suite (the `extended` tests).
+
+## Test Coverage
+
+Test coverage is calculated in the `coverage` workflow.
+It runs on `ubuntu-latest` and `Python 3.9`, and reports the coverage results of the test suite to `CodeClimate`.
+
+Input parameters: 
+  - `src-dir` - a required string, which indicates the name of the directory 
+                containing the source-code for which the coverage is calculated.
+  - `pytest-options` - options to be passed on to `pytest`, e.g. `-m "not cern_network"` (defaults to an empty string).
+
+Secrets:
+  - `CC_TEST_REPORTER_ID` - The CodeClimate test-reporter ID.
+
+This workflow should be triggered on pushes to `master` and any push to a `pull request`
+
+## Regular Testing
+
+A `cron` workflow runs the full testing suite, on all available operating systems and supported Python versions.
+It is very similar to the normal Testing Suite, but in addition also runs on `Python 3.x` so that newly released Python versions that would break tests are automatically included.
+
+Input parameters are: 
+  - `pytest-options` - options to be passed on to `pytest`, e.g. `-m "not cern_network"` (defaults to an empty string).
+
+The workflow should be triggered in regular intervals, e.g. every Monday at 3am (UTC time).
+
+## Publishing
+
+Publishing to `PyPI` is done through the `publish` workflow, 
+which builds a `wheel`, checks it, and pushes to `PyPI` if checks are successful.
+
+Secrets:
+  - `PYPI_USERNAME` - The pypi username.
+  - `PYPI_PASSWORD` - The pypi password.
+
+This workflow should be set to trigger anytime a `release` is made of the GitHub repository.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,10 +5,12 @@ They are organized as follows.
 
 ## Documentation
 
-The `documentation` workflow builds the documentation and pushes it to the `gh-pages` branch (if the build is successful).
+The `documentation` workflow builds the documentation. 
 It runs on `ubuntu-latest` and one of our supported version, currently `Python 3.9`.
+If the workflow is run from `master` it pushes the successfully build documentation to the `gh-pages` branch,
+if it is run from a `pull_request` the documentation is uploaded as an artifact to allow manual checks.
 
-It should be triggered on any push to `master`.
+This workflow should only be triggered on pushes to `master` and on `pull_request`s.
 
 ## Testing Suite
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,14 +22,13 @@ Tests are ensured in the `tests` workflow.
 Tests run on a matrix of all supported operating systems (`ubuntu-20.04`, `ubuntu-22.04`, `windows-latest` and `macos-latest`) for all supported Python versions (currently `3.8` to `3.11`).
 
 Input parameters: 
-  - `name` - an optional string, to identify different pytest-configurations (defaults to `tests`).
   - `pytest-options` - options to be passed on to `pytest`, e.g. `-m "not extended and not cern_network"` (defaults to an empty string).
   - `extra-dependencies` - name of the extra dependencies required to run the tests (defaults to `test`).
   - `dependency-file` - name of the file which contains the dependencies (used to get a hash-id for the caching).
 
-These tests are usually run in two stages, which is easy to achieve by calling the test with different `pytest-options`.
-It should be run on all push events except to `master`. 
-The first stage runs our simple tests (the `basic` tests) , and the second one runs the rest of the testing suite (the `extended` tests).
+These tests could easily be run in two stages by calling the test with different `pytest-options`.
+E.g. the first stage runs our simple tests (the `basic` tests), and the second one runs the rest of the testing suite (the `extended` tests).
+The workflow should be run on all push-events except to `master`. 
 
 ## Test Coverage
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,10 +54,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python $python-version
+      - name: Set up Python ${{ env.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: $python-version
+          python-version: ${{ env.python-version }}
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,14 @@ on:
       pytest-options:
         required: false 
         type: string
+      extra-dependencies:
+        required: false 
+        type: string
+        default: test
+      dependency-file:
+        required: false 
+        type: string
+        default: setup.py
     secrets: 
         CC_TEST_REPORTER_ID:
             required: true
@@ -54,13 +62,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/setup.py'
+          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
-        run: python -m pip install '.[test]'
+        run: python -m pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Set up env for CodeClimate (push)
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,20 +47,17 @@ defaults:
 
 jobs:
   coverage:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:  # only a single supported Python on latest ubuntu
-        os: [ubuntu-latest]
-        python-version: [3.9]
+    runs-on: ubuntu-latest
+    env:
+        python-version: 3.9
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python $python-version
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: $python-version
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,7 @@
 #   coverage:
 #       uses: pylhc/.github/.github/workflows/coverage.yml@master
 #       with:
+#         src-dir: omc3
 #         pytest-options: -m "not cern_network"
 #       secrets: inherit
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,93 @@
+# Caller Template --------------------------------------------------------------
+
+# # Runs all tests and pushes coverage report to codeclimate
+# name: Coverage
+
+# on:  # Runs on all push events to master branch and any push related to a pull request
+#   push:
+#     branches:
+#       - master
+#   pull_request:  # so that codeclimate gets coverage and reports on the diff
+
+# jobs:
+#   coverage:
+#       uses: pylhc/.github/.github/workflows/coverage.yml@master
+#       with:
+#         pytest-options: -m "not cern_network"
+#       secrets: inherit
+
+# ------------------------------------------------------------------------------
+name: Reusable Testing with Coverage 
+
+on:
+  workflow_call:
+    inputs:
+      src-dir:
+        required: true 
+        type: string
+      pytest-options:
+        required: false 
+        type: string
+    secrets: 
+        CC_TEST_REPORTER_ID:
+            required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  coverage:
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:  # only a single supported Python on latest ubuntu
+        os: [ubuntu-latest]
+        python-version: [3.9]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: '**/setup.py'
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install package
+        run: python -m pip install '.[test]'
+
+      - name: Set up env for CodeClimate (push)
+        run: |
+          echo "GIT_BRANCH=${GITHUB_REF/refs\/heads\//}" >> $GITHUB_ENV
+          echo "GIT_COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+        if: github.event_name == 'push'
+
+      - name: Set up env for CodeClimate (pull_request)
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "GIT_BRANCH=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+          echo "GIT_COMMIT_SHA=$PR_HEAD_SHA" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+
+      - name: Prepare CodeClimate binary
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        run: |
+          curl -LSs 'https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64' >./cc-test-reporter;
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+
+      - name: Run all tests
+        run: python -m pytest ${{ inputs.pytest-options }} --cov-report xml --cov=${{ inputs.src-dir }}
+
+      - name: Push Coverage to CodeClimate
+        if: ${{ success() }}  # only if tests were successful
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        run: ./cc-test-reporter after-build

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,58 @@
+# Caller Template --------------------------------------------------------------
+
+# # Runs all tests on master everyday at 10 am (UTC time)
+# name: Cron Testing
+
+
+# on:  # Runs on master branch on Mondays at 3am UTC time
+#   schedule:
+#     - cron:  '* 3 * * mon'
+
+# jobs:
+#     tests:
+#       uses: pylhc/.github/.github/workflows/cron.yml@master
+#       with:
+#         pytest-options: -m "not cern_network"
+
+# ------------------------------------------------------------------------------
+name: Reusable Cron-Testing
+
+on:
+  workflow_call:
+    inputs:
+      pytest-options:
+        required: false 
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
+        python-version: [3.8, 3.9, "3.10", "3.11", 3.x]  # crons should always run latest python hence 3.x
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: '**/setup.py'
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install package
+        run: python -m pip install '.[test]'
+
+      - name: Run Tests
+        run: python -m pytest ${{ inputs.pytest-options }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,10 +1,10 @@
 # Caller Template --------------------------------------------------------------
 
-# # Runs all tests on master everyday at 10 am (UTC time)
+# # Runs all tests on master on Mondays at 3 am (UTC time)
 # name: Cron Testing
 
 
-# on:  # Runs on master branch on Mondays at 3am UTC time
+# on: 
 #   schedule:
 #     - cron:  '* 3 * * mon'
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -23,6 +23,14 @@ on:
       pytest-options:
         required: false 
         type: string
+      extra-dependencies:
+        required: false 
+        type: string
+        default: test
+      dependency-file:
+        required: false 
+        type: string
+        default: setup.py
 
 defaults:
   run:
@@ -46,13 +54,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/setup.py'
+          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
-        run: python -m pip install '.[test]'
+        run: python -m pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Run Tests
         run: python -m pytest ${{ inputs.pytest-options }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,70 @@
+# Caller Template --------------------------------------------------------------
+
+# # Build documentation
+# # The build is uploaded as artifact if the triggering event is a push for a pull request
+# # The build is published to github pages if the triggering event is a push to the master branch (PR merge)
+# name: Build and upload documentation
+
+# on:  # Runs on any push event in a PR or any push event to master
+#   pull_request:
+#   push:
+#     branches:
+#       - 'master'
+
+# jobs:
+#   documentation:
+#         uses: pylhc/.github/.github/workflows/documentation.yml@master
+
+# ------------------------------------------------------------------------------
+name: Reusable Build-Documentation
+
+on:
+  workflow_call:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  documentation:
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:  # only a single supported Python on latest ubuntu
+        os: [ubuntu-latest]
+        python-version: [3.9]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: '**/setup.py'
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install package
+        run: python -m pip install '.[doc]'
+
+      - name: Build documentation
+        run: python -m sphinx -b html doc ./doc_build -d ./doc_build
+
+      - name: Upload build artifacts  # upload artifacts so reviewers can have a quick look without building documentation from the branch locally
+        uses: actions/upload-artifact@v2
+        if: success() && github.event_name == 'pull_request'  # only for pushes in PR
+        with:
+          name: site-build
+          path: doc_build
+          retention-days: 5
+
+      - name: Upload documentation to gh-pages
+        if: success() && github.ref == 'refs/heads/master'  # only for pushes to master
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: doc_build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,20 +36,17 @@ defaults:
 
 jobs:
   documentation:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:  # only a single supported Python on latest ubuntu
-        os: [ubuntu-latest]
-        python-version: [3.9]
+    runs-on: ubuntu-latest
+    env:
+        python-version: 3.9
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python $python-version
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: $python-version
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python $python-version
+      - name: Set up Python ${{ env.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: $python-version
+          python-version: ${{ env.python-version }}
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,6 +20,15 @@ name: Reusable Build-Documentation
 
 on:
   workflow_call:
+    inputs:
+      extra-dependencies:
+        required: false 
+        type: string
+        default: doc 
+      dependency-file:
+        required: false 
+        type: string
+        default: setup.py
 
 defaults:
   run:
@@ -42,13 +51,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/setup.py'
+          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
-        run: python -m pip install '.[doc]'
+        run: python -m pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Build documentation
         run: python -m sphinx -b html doc ./doc_build -d ./doc_build

--- a/.github/workflows/echo_test.yml
+++ b/.github/workflows/echo_test.yml
@@ -1,4 +1,6 @@
-name: Reusable workflow example
+# Simple reusable workflow, to test workflows calls with input
+
+name: Echo Test Workflow 
 
 defaults:
   run:
@@ -9,8 +11,9 @@ on:
   workflow_call:
     inputs:
       test-input:
-        required: true
+        required: false
         type: string
+        default: "DEFAULT INPUT"   # without default: empty string
     
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+# Caller Template --------------------------------------------------------------
+
+# # Publishes to PyPI upon creation of a release
+# name: Upload Package to PyPI
+
+# on:  # Runs everytime a release is added to the repository
+#   release:
+#     types: [created]
+
+# jobs:
+#   deploy:
+#     uses: pylhc/.github/.github/workflows/publish.yml@master
+#     secrets: inherit
+
+# ------------------------------------------------------------------------------
+name: Reusable PyPI Upload
+
+on:
+  workflow_call:
+    secrets: 
+        PYPI_USERNAME:
+            required: true
+        PYPI_PASSWORD:
+            required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:  # only a single supported Python on latest ubuntu
+        os: [ubuntu-latest]
+        python-version: [3.9]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: '**/setup.py'
+
+      - name: Upgrade pip, setuptools, wheel, build and twine
+        run: python -m pip install --upgrade pip setuptools wheel build twine
+
+      - name: Build and check build
+        run: |
+          python -m build
+          twine check dist/*
+
+      - name: Publish
+        if: ${{ success() }}
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          twine upload dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,21 +33,18 @@ defaults:
     shell: bash
 
 jobs:
-  deploy:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:  # only a single supported Python on latest ubuntu
-        os: [ubuntu-latest]
-        python-version: [3.9]
+  deploy: # only a single supported Python on latest ubuntu
+    runs-on: ubuntu-latest
+    env:
+        python-version: 3.9
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python $python-version
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: $python-version
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,10 +41,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python $python-version
+      - name: Set up Python ${{ env.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: $python-version
+          python-version: ${{ env.python-version }}
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,11 @@ name: Reusable PyPI Upload
 
 on:
   workflow_call:
+    inputs:
+      dependency-file:
+        required: false 
+        type: string
+        default: setup.py
     secrets: 
         PYPI_USERNAME:
             required: true
@@ -44,7 +49,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/setup.py'
+          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Upgrade pip, setuptools, wheel, build and twine
         run: python -m pip install --upgrade pip setuptools wheel build twine

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -1,0 +1,23 @@
+name: Reusable workflow example
+
+defaults:
+  run:
+    shell: bash
+
+
+on:
+  workflow_call:
+    inputs:
+      test-input:
+        required: true
+        type: string
+    
+
+jobs:
+  run-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo the input
+        run: |
+          echo ${{ inputs.test-input }}
+    

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ defaults:
     shell: bash
 
 jobs:
-  tests:  # Runs the basic tests, aka all tests not marked with "extended", on all push events
+  tests: 
     name: ${{ inputs.name }} / ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -78,5 +78,5 @@ jobs:
       - name: Install package
         run: python -m pip install '.[${{ inputs.extra-dependencies }}]'
 
-      - name: Run Basic Tests
+      - name: Run Tests  (${{ inputs.name }})
         run: python -m pytest ${{ inputs.pytest-options }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,6 @@ name: Reusable Testing
 on:
   workflow_call:
     inputs:
-      name:
-        required: false 
-        type: string
-        default: "tests"
       pytest-options:
         required: false 
         type: string
@@ -54,7 +50,7 @@ defaults:
 
 jobs:
   tests: 
-    name: ${{ inputs.name }} / ${{ matrix.os }} / ${{ matrix.python-version }}
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -78,5 +74,5 @@ jobs:
       - name: Install package
         run: python -m pip install '.[${{ inputs.extra-dependencies }}]'
 
-      - name: Run Tests  (${{ inputs.name }})
+      - name: Run Tests
         run: python -m pytest ${{ inputs.pytest-options }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,74 @@
+# Caller Template Extended -----------------------------------------------------
+
+# # Runs all tests in two steps: the basic tests and the "extended" tests
+# name: Tests
+
+# defaults:
+#   run:
+#     shell: bash
+
+# on:  # Runs on any push event to any branch except master (the coverage workflow takes care of that)
+#   push:
+#     branches-ignore:
+#       - 'master'
+
+# jobs:
+#     basic-tests:
+#       uses: pylhc/.github/.github/workflows/tests.yml@master
+#       with:
+#         name: basic
+#         pytest-options: -m "not extended and not cern_network"
+
+#     extended-tests:
+#       needs: basic-tests
+#       uses: pylhc/.github/.github/workflows/tests.yml@master
+#       with:
+#         name: extended
+#         pytest-options: -m "extended and not cern_network"
+
+# ------------------------------------------------------------------------------
+name: Reusable Testing
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: false 
+        type: string
+        default: "tests"
+      pytest-options:
+        required: false 
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:  # Runs the basic tests, aka all tests not marked with "extended", on all push events
+    name: ${{ inputs.name }} / ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
+        python-version: [3.8, 3.9, "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: '**/setup.py'
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install package
+        run: python -m pip install '.[test]'
+
+      - name: Run Basic Tests
+        run: python -m pytest ${{ inputs.pytest-options }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,14 +16,12 @@
 #     basic-tests:
 #       uses: pylhc/.github/.github/workflows/tests.yml@master
 #       with:
-#         name: basic
 #         pytest-options: -m "not extended and not cern_network"
 
 #     extended-tests:
 #       needs: basic-tests
 #       uses: pylhc/.github/.github/workflows/tests.yml@master
 #       with:
-#         name: extended
 #         pytest-options: -m "extended and not cern_network"
 
 # ------------------------------------------------------------------------------

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,14 @@ on:
       pytest-options:
         required: false 
         type: string
+      extra-dependencies:
+        required: false 
+        type: string
+        default: test
+      dependency-file:
+        required: false 
+        type: string
+        default: setup.py
 
 defaults:
   run:
@@ -62,13 +70,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/setup.py'
+          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
-        run: python -m pip install '.[test]'
+        run: python -m pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Run Basic Tests
         run: python -m pytest ${{ inputs.pytest-options }}


### PR DESCRIPTION
Create reusable workflows, so that when we make changes in the used python versions/OS/actions etc. we don't need to propagate everything to all the packages.