### PR TITLE
Bump upload-artifact and JamesIves/github-pages-deploy-action versions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -60,7 +60,7 @@ jobs:
         run: python -m sphinx -b html doc ./doc_build -d ./doc_build
 
       - name: Upload build artifacts  # upload artifacts so reviewers can have a quick look without building documentation from the branch locally
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success() && github.event_name == 'pull_request'  # only for pushes in PR
         with:
           name: site-build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -69,8 +69,8 @@ jobs:
 
       - name: Upload documentation to gh-pages
         if: success() && github.ref == 'refs/heads/master'  # only for pushes to master
-        uses: JamesIves/github-pages-deploy-action@3.6.2
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: doc_build
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: doc_build


### PR DESCRIPTION
Closes #2 

The `upload-artifact` actions is now called with `v3`, which will remove the deprecation warnings.

The `JamesIves/github-pages-deploy-action` is also bumped to `v4` (from `v3.6.2`), and the keys have been changed to kebab-case and lowercase as specified in the [v3 to v4 migration guide](https://github.com/JamesIves/github-pages-deploy-action/discussions/592). This also avoids using the deprecated `node12` (it should now use `node16`).