### PR TITLE
Updates to versions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ They are organized as follows.
 ## Documentation
 
 The `documentation` workflow builds the documentation. 
-It runs on `ubuntu-latest` and one of our supported version, currently `Python 3.9`.
+It runs on `ubuntu-latest` and one of our supported version, currently `Python 3.11`.
 If the workflow is run from `master` it pushes the successfully build documentation to the `gh-pages` branch,
 if it is run from a `pull_request` the documentation is uploaded as an artifact to allow manual checks.
 
@@ -19,7 +19,7 @@ This workflow should only be triggered on pushes to `master` and on `pull_reques
 ## Testing Suite
 
 Tests are ensured in the `tests` workflow.
-Tests run on a matrix of all supported operating systems (`ubuntu-20.04`, `ubuntu-22.04`, `windows-latest` and `macos-latest`) for all supported Python versions (currently `3.8` to `3.11`).
+Tests run on a matrix of all supported operating systems (`ubuntu-20.04`, `ubuntu-22.04`, `windows-latest` and `macos-latest`) for all supported Python versions (currently `3.8` to `3.12`).
 
 Input parameters: 
   - `pytest-options` - options to be passed on to `pytest`, e.g. `-m "not extended and not cern_network"` (defaults to an empty string).
@@ -33,7 +33,7 @@ The workflow should be run on all push-events except to `master`.
 ## Test Coverage
 
 Test coverage is calculated in the `coverage` workflow.
-It runs on `ubuntu-latest` and `Python 3.9`, and reports the coverage results of the test suite to `CodeClimate`.
+It runs on `ubuntu-latest` and `Python 3.11`, and reports the coverage results of the test suite to `CodeClimate`.
 
 Input parameters: 
   - `src-dir` - a required string, which indicates the name of the directory 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,13 +49,13 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     env:
-        python-version: 3.9
+        python-version: 3.11
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ env.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python-version }}
           cache: 'pip'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -44,13 +44,13 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
         # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.8, 3.9, "3.10", "3.11", 3.x]  # crons should always run latest python hence 3.x
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.x]  # crons should always run latest python hence 3.x
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,13 +38,13 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     env:
-        python-version: 3.9
+        python-version: 3.11
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ env.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python-version }}
           cache: 'pip'
@@ -60,7 +60,7 @@ jobs:
         run: python -m sphinx -b html doc ./doc_build -d ./doc_build
 
       - name: Upload build artifacts  # upload artifacts so reviewers can have a quick look without building documentation from the branch locally
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() && github.event_name == 'pull_request'  # only for pushes in PR
         with:
           name: site-build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,13 +36,13 @@ jobs:
   deploy: # only a single supported Python on latest ubuntu
     runs-on: ubuntu-latest
     env:
-        python-version: 3.9
+        python-version: 3.11
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ env.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python-version }}
           cache: 'pip'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,13 +54,13 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
         # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'


### PR DESCRIPTION
**Changes:**
- Upping actions versions where relevant
- Upping Python versions where a specific one is used (usually 3.9 -> 3.11)
- Added 3.12 to the `tests` matrix and explicitely to the `cron` matrix
