### PR TITLE
Drop Python 3.8 and minor updates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ They are organized as follows.
 ## Documentation
 
 The `documentation` workflow builds the documentation. 
-It runs on `ubuntu-latest` and one of our supported version, currently `Python 3.11`.
+It runs on `ubuntu-latest` and one of our supported version, currently `Python 3.12`.
 If the workflow is run from `master` it pushes the successfully build documentation to the `gh-pages` branch,
 if it is run from a `pull_request` the documentation is uploaded as an artifact to allow manual checks.
 
@@ -19,7 +19,7 @@ This workflow should only be triggered on pushes to `master` and on `pull_reques
 ## Testing Suite
 
 Tests are ensured in the `tests` workflow.
-Tests run on a matrix of all supported operating systems (`ubuntu-20.04`, `ubuntu-22.04`, `windows-latest` and `macos-latest`) for all supported Python versions (currently `3.8` to `3.12`).
+Tests run on a matrix of all supported operating systems (`ubuntu-22.04`, `ubuntu-24.04`, `windows-latest` and `macos-latest`) for all supported Python versions (currently `3.9` to `3.12`).
 
 Input parameters: 
   - `pytest-options` - options to be passed on to `pytest`, e.g. `-m "not extended and not cern_network"` (defaults to an empty string).
@@ -33,7 +33,7 @@ The workflow should be run on all push-events except to `master`.
 ## Test Coverage
 
 Test coverage is calculated in the `coverage` workflow.
-It runs on `ubuntu-latest` and `Python 3.11`, and reports the coverage results of the test suite to `CodeClimate`.
+It runs on `ubuntu-latest` and `Python 3.12`, and reports the coverage results of the test suite to `CodeClimate`.
 
 Input parameters: 
   - `src-dir` - a required string, which indicates the name of the directory 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,7 +49,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     env:
-        python-version: 3.11
+        python-version: 3.12
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -42,9 +42,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
         # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.x]  # crons should always run latest python hence 3.x
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.x]  # crons should always run latest python hence 3.x
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     env:
-        python-version: 3.11
+        python-version: 3.12
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
   deploy: # only a single supported Python on latest ubuntu
     runs-on: ubuntu-latest
     env:
-        python-version: 3.11
+        python-version: 3.12
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,9 +52,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
         # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR:

- Drops `Python 3.8` from versions
- Drops `ubuntu-20.04` from runners
- Adds `ubuntu-24.04` in runners
- Changes coverage, documentation and publishing workflows to use `3.12` from `3.11`
- Propagates theses changes to the `README` descriptions