### PR TITLE
Brew install hdf5

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -49,6 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - if: matrix.os == 'macos-latest'
+        name: Set up hdf5
+        run: brew install hdf5
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - if: matrix.os == 'macos-latest'
+        name: Set up hdf5
+        run: brew install hdf5
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Adding a step to install `hdf5` on `macos-latest` runners, as we rely on it for a bunch of packages.