### PR TITLE
Remove Python 3.9

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -43,8 +43,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
-        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.9, "3.10", 3.11, 3.12, 3.x]  # crons should always run latest python hence 3.x
+        # We escape with quotes so it doesn't get interpreted as float (e.g. 3.10 -> 3.1 by GA's parser)
+        python-version: ["3.10", "3.11", "3.12", "3.x"]  # crons should always run latest python hence 3.x
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,8 +53,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
-        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.9, "3.10", 3.11, 3.12]
+        # We escape with quotes so it doesn't get interpreted as float (e.g. 3.10 -> 3.1 by GA's parser)
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Since we are finally dropping Python 3.9 support, I'm removing it from our CI matrices.

**Note:** in this PR I do not change the 3.12 setting to 3.13, nor do I explicitely add 3.13 to the matrices yet. This is because for our workflows requiring `cpymad` the install step currently fails on Python 3.13. I have opened an issue there (https://github.com/hibtc/cpymad/issues/141) and we can move on once that is resolved.