### PR TITLE
Updating with Python 3.13

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -77,8 +77,7 @@ Secrets:
 
 This workflow should be set to trigger anytime a `release` is made of the GitHub repository.
 
-
 ## Assign Labels
 
-Assign labels from json definition file in `labels/` to selected pylhc repos. 
+Assign labels from json definition file in `labels/` to selected pylhc repos.
 This is not a re-usable workflow, but runs on every push to `master` on THIS repo.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,7 +49,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     env:
-        python-version: 3.12
+        python-version: 3.13
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
         # We escape with quotes so it doesn't get interpreted as float (e.g. 3.10 -> 3.1 by GA's parser)
-        python-version: ["3.10", "3.11", "3.12", "3.x"]  # crons should always run latest python hence 3.x
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.x"]  # crons should always run latest python hence 3.x
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     env:
-        python-version: 3.12
+        python-version: 3.13
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
   deploy: # only a single supported Python on latest ubuntu
     runs-on: ubuntu-latest
     env:
-        python-version: 3.12
+        python-version: 3.13
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,11 +41,15 @@ on:
         required: false 
         type: string
         default: pyproject.toml
+      cancel-in-progress:
+        required: false
+        type: boolean
+        default: true
 
-# Cancel in-progress workflows when pushing a new commit on the same branch
+# Cancel (by default) in-progress workflows when pushing a new commit on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 defaults:
   run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
         # We escape with quotes so it doesn't get interpreted as float (e.g. 3.10 -> 3.1 by GA's parser)
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ on:
       cancel-in-progress:
         required: false
         type: boolean
-        default: true
+        default: false
 
 # Cancel (by default) in-progress workflows when pushing a new commit on the same branch
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,11 @@ on:
         type: string
         default: pyproject.toml
 
+# Cancel in-progress workflows when pushing a new commit on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Adding `Python 3.13` to matrices now that `cpymad` has published wheels for it, or simply replacing 3.12 for 3.13 where relevant.

Experimentally I was tempted to add an option to terminate some jobs when more are added to the pile. For instance, if someone pushes a few commits in quick succession to the `omc3` repo, which is CI intensive, these can take a very long time to all run when the changes across these commits are probably small.

I have added a few lines to make workflows terminate if a commit is pushed on the same branch, for the `tests` workflow. I have also added an input option to turn this behaviour on or off. Currently it is ON, but it could be OFF by default. Curious to get your opinion.