### PR TITLE
Remove step

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -71,9 +71,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
-      - name: Upgrade pip, setuptools and wheel
-        run: uv pip install --upgrade pip setuptools wheel
-
       - name: Install package
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -70,9 +70,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
-      - name: Upgrade pip, setuptools and wheel
-        run: uv pip install --upgrade pip setuptools wheel
-
       - name: Install package
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -60,9 +60,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
-      - name: Upgrade pip, setuptools and wheel
-        run: uv pip install --upgrade pip setuptools wheel
-
       - name: Install package
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,9 +58,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
-      - name: Upgrade pip, setuptools, wheel, build and twine
-        run: uv pip install --upgrade pip setuptools wheel build twine
-
       - name: Build and check build
         run: |
           python -m build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,9 +89,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
-      - name: Upgrade pip, setuptools and wheel
-        run: uv pip install --upgrade pip setuptools wheel
-
       - name: Install package
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 


### PR DESCRIPTION
We should not have a need for this step anymore as it dates back to still using `setup.py` files and `setuptools`, plus `wheel` for builds (before [PEP518](https://peps.python.org/pep-0518/) really kicked in through the ecosystem).

It's not like the step takes any kind of time anyway since `uv pip` is fast, but it's nice to get rid of the cruft.