### PR TITLE
Remove cache from setup-python

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,10 +66,6 @@ jobs:
 
       - name: Set up Python ${{ env.python-version }}
         uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Install package
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -65,10 +65,6 @@ jobs:
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Install package
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -55,10 +55,6 @@ jobs:
 
       - name: Set up Python ${{ env.python-version }}
         uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Install package
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,10 +53,6 @@ jobs:
 
       - name: Set up Python ${{ env.python-version }}
         uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Build and check build
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,10 +84,6 @@ jobs:
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/${{ inputs.dependency-file }}'
 
       - name: Install package
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'


### PR DESCRIPTION
Removing the `with` clause in our `setup-python` steps. This removes its handling of the cache, since the `uv` step already takes care of its cache and we are seeing strange cache misses on some python versions (see: https://github.com/pylhc/omc3/actions/runs/15671760540/job/44144034030).