### PR TITLE
Exclusively use UV for setting up

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,10 +41,6 @@ on:
         CC_TEST_REPORTER_ID:
             required: true
 
-# We use uv pip and it should use the system python from our runner
-env:
-  UV_SYSTEM_PYTHON: 1
-
 defaults:
   run:
     shell: bash
@@ -53,23 +49,21 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     env:
-        python-version: 3.13
+        python-version: "3.13"
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
+      - name: Install uv and Python
         uses: astral-sh/setup-uv@v5
         with:
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
-      - name: Set up Python ${{ env.python-version }}
-        uses: actions/setup-python@v5
-
-      # The uv pip option is meant for CI runners, since setup-python creates a system-wide Python
+      # The uv pip should make & use an env from the Python install of the previous step
       - name: Install package
-        run: uv pip install --break-system-packages '.[${{ inputs.extra-dependencies }}]'
+        run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Set up env for CodeClimate (push)
         run: |
@@ -94,7 +88,7 @@ jobs:
           ./cc-test-reporter before-build
 
       - name: Run all tests
-        run: python -m pytest ${{ inputs.pytest-options }} --cov-report xml --cov=${{ inputs.src-dir }}
+        run: uv run python -m pytest ${{ inputs.pytest-options }} --cov-report xml --cov=${{ inputs.src-dir }}
 
       - name: Push Coverage to CodeClimate
         if: ${{ success() }}  # only if tests were successful

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -32,10 +32,6 @@ on:
         type: string
         default: pyproject.toml
 
-# We use uv pip and it should use the system python from our runner
-env:
-  UV_SYSTEM_PYTHON: 1
-
 defaults:
   run:
     shell: bash
@@ -48,7 +44,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
         # We escape with quotes so it doesn't get interpreted as float (e.g. 3.10 -> 3.1 by GA's parser)
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.x"]  # crons should always run latest python hence 3.x
+        python-version: ["3.10", "3.11", "3.12", "3.13"]  # add new versions when they are released
 
     steps:
       - uses: actions/checkout@v4
@@ -57,18 +53,16 @@ jobs:
         name: Set up hdf5
         run: brew install hdf5
 
-      - name: Install uv
+      - name: Install uv and Python
         uses: astral-sh/setup-uv@v5
         with:
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-
-      # The uv pip option is meant for CI runners, since setup-python creates a system-wide Python
+      # The uv pip should make & use an env from the Python install of the previous step
       - name: Install package
-        run: uv pip install --break-system-packages '.[${{ inputs.extra-dependencies }}]'
+        run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Run Tests
-        run: python -m pytest ${{ inputs.pytest-options }}
+        run: uv run python -m pytest ${{ inputs.pytest-options }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,10 +30,6 @@ on:
         type: string
         default: pyproject.toml
 
-# We use uv pip and it should use the system python from our runner
-env:
-  UV_SYSTEM_PYTHON: 1
-
 defaults:
   run:
     shell: bash
@@ -42,26 +38,24 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     env:
-        python-version: 3.13
+        python-version: "3.13"
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
+      - name: Install uv and Python
         uses: astral-sh/setup-uv@v5
         with:
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
-      - name: Set up Python ${{ env.python-version }}
-        uses: actions/setup-python@v5
-
-      # The uv pip option is meant for CI runners, since setup-python creates a system-wide Python
+      # The uv pip should make & use an env from the Python install of the previous step
       - name: Install package
-        run: uv pip install --break-system-packages '.[${{ inputs.extra-dependencies }}]'
+        run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Build documentation
-        run: python -m sphinx -b html doc ./doc_build -d ./doc_build
+        run: uv run python -m sphinx -b html doc ./doc_build -d ./doc_build
 
       - name: Upload build artifacts  # upload artifacts so reviewers can have a quick look without building documentation from the branch locally
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,6 @@ on:
         PYPI_PASSWORD:
             required: true
 
-# We use uv pip and it should use the system python from our runner
-env:
-  UV_SYSTEM_PYTHON: 1
-
 defaults:
   run:
     shell: bash
@@ -40,16 +36,10 @@ jobs:
   deploy: # only a single supported Python on latest ubuntu
     runs-on: ubuntu-latest
     env:
-        python-version: 3.13
+        python-version: "3.13"
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       - name: Set up Python ${{ env.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,10 +46,6 @@ on:
         type: boolean
         default: false
 
-# We use uv pip and it should use the system python from our runner
-env:
-  UV_SYSTEM_PYTHON: 1
-
 # Cancel (by default) in-progress workflows when pushing a new commit on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -67,7 +63,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
         # We escape with quotes so it doesn't get interpreted as float (e.g. 3.10 -> 3.1 by GA's parser)
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]  # add new versions when they are released
 
     steps:
       - uses: actions/checkout@v4
@@ -76,18 +72,16 @@ jobs:
         name: Set up hdf5
         run: brew install hdf5
 
-      - name: Install uv
+      - name: Install uv and Python
         uses: astral-sh/setup-uv@v5
         with:
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-
-      # The uv pip option is meant for CI runners, since setup-python creates a system-wide Python
+      # The uv pip should make & use an env from the Python install of the previous step
       - name: Install package
-        run: uv pip install --break-system-packages '.[${{ inputs.extra-dependencies }}]'
+        run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Run Tests
-        run: python -m pytest ${{ inputs.pytest-options }}
+        run: uv run python -m pytest ${{ inputs.pytest-options }}


### PR DESCRIPTION
This PR removes the `setup-python` so there is no "SYSTEM" Python shenanigans.

Instead the `setup-uv` action installs both `uv` and creates a Python installation from the `${{ matrix.python-version }}`.

At the `uv pip` call, it should trigger to use a managed Python to create a `venv` (`uv` only allows `venv` usage unless some specific options are passed) and install in there.

Following steps use `uv run` which should trigger from the correct env. All of this is a little speculative.


Other changes:
- Escaped all python versions with quotes, safer with the yaml parsing engine.
- Removed 3.x from the crons as `uv` does not accept this syntax, and we can keep the list updated.
- Removed uv from the publish workflow altogether as it was not used, and this workflow is dead simple.