### PR TITLE
Explicitely activate uv venv

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -89,7 +89,7 @@ jobs:
           ./cc-test-reporter before-build
 
       - name: Run all tests
-        run: uv run python -m pytest ${{ inputs.pytest-options }} --cov-report xml --cov=${{ inputs.src-dir }}
+        run: python -m pytest ${{ inputs.pytest-options }} --cov-report xml --cov=${{ inputs.src-dir }}
 
       - name: Push Coverage to CodeClimate
         if: ${{ success() }}  # only if tests were successful

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           python-version: ${{ env.python-version }}
           enable-cache: true
+          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -66,4 +66,4 @@ jobs:
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Run Tests
-        run: uv run python -m pytest ${{ inputs.pytest-options }}
+        run: python -m pytest ${{ inputs.pytest-options }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           python-version: ${{ env.python-version }}
           enable-cache: true
+          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Build documentation
-        run: uv run python -m sphinx -b html doc ./doc_build -d ./doc_build
+        run: python -m sphinx -b html doc ./doc_build -d ./doc_build
 
       - name: Upload build artifacts  # upload artifacts so reviewers can have a quick look without building documentation from the branch locally
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,4 +85,4 @@ jobs:
         run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Run Tests
-        run: uv run python -m pytest ${{ inputs.pytest-options }}
+        run: python -m pytest ${{ inputs.pytest-options }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step


### PR DESCRIPTION
Should avoid the shadow reinstall of the package at test step, with all extras (which fails for omc3 due to AccPy issues).

Will test with the state of this branch from my omc3 branch