### PR TITLE
Update to setup-uv@v6

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,10 +55,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: ${{ env.python-version }}
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
+          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.python-version }}
           enable-cache: true
           activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           python-version: ${{ env.python-version }}
           enable-cache: true
-          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -54,10 +54,11 @@ jobs:
         run: brew install hdf5
 
       - name: Install uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           python-version: ${{ env.python-version }}
           enable-cache: true
-          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.python-version }}
           enable-cache: true
           activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,10 +44,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: ${{ env.python-version }}
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
+          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-          activate-environment: true
+          # activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,10 +73,11 @@ jobs:
         run: brew install hdf5
 
       - name: Install uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-          # activate-environment: true
           cache-dependency-glob: '${{ inputs.dependency-file }}'
 
       # The uv pip should make & use an env from the Python install of the previous step


### PR DESCRIPTION
Shifts the workflows to use the latest version of `setup-uv`. This should also solve the "Unexpected input" warnings since `activate-environment` option is a new feature.