### PR TITLE
Compile the bytecode after install, like pip does

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,6 +41,9 @@ on:
         CC_TEST_REPORTER_ID:
             required: true
 
+env:
+  UV_COMPILE_BYTECODE: 1
+
 defaults:
   run:
     shell: bash
@@ -64,7 +67,7 @@ jobs:
 
       # The uv pip should make & use an env from the Python install of the previous step
       - name: Install package
-        run: uv pip install '.[${{ inputs.extra-dependencies }}]' --compile-bytecode
+        run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Set up env for CodeClimate (push)
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -32,6 +32,9 @@ on:
         type: string
         default: pyproject.toml
 
+env:
+  UV_COMPILE_BYTECODE: 1
+
 defaults:
   run:
     shell: bash
@@ -63,7 +66,7 @@ jobs:
 
       # The uv pip should make & use an env from the Python install of the previous step
       - name: Install package
-        run: uv pip install '.[${{ inputs.extra-dependencies }}]' --compile-bytecode
+        run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Run Tests
         run: python -m pytest ${{ inputs.pytest-options }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,6 +30,9 @@ on:
         type: string
         default: pyproject.toml
 
+env:
+  UV_COMPILE_BYTECODE: 1
+
 defaults:
   run:
     shell: bash
@@ -53,7 +56,7 @@ jobs:
 
       # The uv pip should make & use an env from the Python install of the previous step
       - name: Install package
-        run: uv pip install '.[${{ inputs.extra-dependencies }}]' --compile-bytecode
+        run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Build documentation
         run: python -m sphinx -b html doc ./doc_build -d ./doc_build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
+env:
+  UV_COMPILE_BYTECODE: 1
+
 defaults:
   run:
     shell: bash
@@ -82,7 +85,7 @@ jobs:
 
       # The uv pip should make & use an env from the Python install of the previous step
       - name: Install package
-        run: uv pip install '.[${{ inputs.extra-dependencies }}]' --compile-bytecode
+        run: uv pip install '.[${{ inputs.extra-dependencies }}]'
 
       - name: Run Tests
         run: python -m pytest ${{ inputs.pytest-options }}


### PR DESCRIPTION
The bytecode has to be compiled, but it's much faster to ask `uv` to do it at install time than to let the Python VM do it (it's more optimized, and it's parallelized).