### PR TITLE
Publish with uv 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Publish
         if: ${{ success() }}
         env:
-          UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_USERNAME }}
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_PASSWORD }}
         run: |
           uv publish


### PR DESCRIPTION
Seems there is no equivalent to the `twine check` at the moment, and also uncertainty if it's needed: https://github.com/astral-sh/uv/issues/8641
