### PR TITLE
Dropping Python 3.10 from CIs

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
         # We escape with quotes so it doesn't get interpreted as float (e.g. 3.10 -> 3.1 by GA's parser)
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]  # add new versions when they are released
+        python-version: ["3.11", "3.12", "3.13", "3.14"]  # add new versions when they are released
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
         # We escape with quotes so it doesn't get interpreted as float (e.g. 3.10 -> 3.1 by GA's parser)
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]  # add new versions when they are released
+        python-version: ["3.11", "3.12", "3.13", "3.14"]  # add new versions when they are released
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
This PR drops Python 3.10

Considering it is close to EoL, [SPEC0](https://scientific-python.org/specs/spec-0000/) has dropped it long ago and the Acc-Py is based on 3.11 (not for so long anymore) it is safe to remove it.

Note: this requires updating the "required workflows" in our repos after merging. I will take care of it.