### PR TITLE
Enable no failfast option for tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,7 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
         # We escape with quotes so it doesn't get interpreted as float (e.g. 3.10 -> 3.1 by GA's parser)


### PR DESCRIPTION
My thinking is this: by the time one of the test workflows in the matrix reports a failure, other test workflows have also done most of the test run anyway and it would not save much to cancel them at that point.

On the other hand, from time to time we have failures showing up only on certain Python versions + OS combinations and it would be nice to have these insights.